### PR TITLE
Fixed episodes ordering using natural sort

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,7 @@ $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION
This PR fixes the episodes list ordering issue. The array_multisort parameter was changed from SORT_STRING to SORT_NATURAL.

---

**Testing**

In a browser verify that the episodes list is being sorted correctly. The first episode should be Homer The Heretic Season 4 Episode 3.

---

**Deployment steps**

Merge branch `issue1` into `master`

Compile assets: `./bin/node_modules/gulp`
