### PR TITLE
Fixed missing exception handler for Guzzle

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,17 +1,27 @@
 <?php
 require_once '../vendor/autoload.php';
 
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Exception\ServerException;
+
 //Load Twig templating environment
 $loader = new Twig_Loader_Filesystem('../templates/');
 $twig = new Twig_Environment($loader, ['debug' => true]);
 
-//Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
+//Declare an empty array to store Guzzle exceptions.
+$errors = [];
 
-//Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+//Get the episodes from the API
+try {
+    $client = new GuzzleHttp\Client();
+    $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+    $data = json_decode($res->getBody(), true);
+
+    //Sort the episodes
+    array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+} catch ( ServerException $e ) {
+    $errors[] = $e->getMessage();
+}
 
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+echo $twig->render('page.html', ["episodes" => $data, "errors" => $errors]);

--- a/templates/page.html
+++ b/templates/page.html
@@ -15,13 +15,19 @@
     </div>
 
     <div class="container">
-        {% for episode in episodes %}
-            {% if loop.index%2 == 1 %}<div class="row">{%endif %}
+        {% if errors is not empty %}
+            <div class="alert alert-danger">
+                Sorry, there was an error. Please try again by reloading the page.
+            </div>
+        {% else %}
+            {% for episode in episodes %}
+                {% if loop.index%2 == 1 %}<div class="row">{%endif %}
 
-                {{ include('episode.html') }}
-        
-            {% if loop.index%2 == 0 %}</div>{%endif %}
-        {% endfor %}
+                    {{ include('episode.html') }}
+
+                {% if loop.index%2 == 0 %}</div>{%endif %}
+            {% endfor %}
+        {% endif %}
     </div>
 
     <footer class="footer">


### PR DESCRIPTION
This PR fixes the uncaught Guzzle exception. An exception handler and a related HTML error message have been implemented.

---

**Testing**

In a browser verify that the Guzzle fatal error has been replaced by an HTML error with the following copy: "Sorry, there was an error. Please try again by reloading the page.".

---

**Deployment steps**

Merge branch `issue2` into `master`

Compile assets: `./bin/node_modules/gulp`
