### PR TITLE
Fixed multiple popovers issue

### DIFF
--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -14,8 +14,9 @@ module.exports = function () {
         container: 'body',
         viewport: { selector: 'body', padding: 20 }
     })
-    
-    // Initialise Bootstrap tooltips
-    //http://getbootstrap.com/javascript/#tooltips
-    $('[data-toggle="tooltip"]').tooltip()
+
+    // Destroy an existing popover
+    $('[data-toggle="popover"]').click(function(e) {
+      $('.popover').popover('destroy')
+    })
 }


### PR DESCRIPTION
This PR fixes the multiple popovers issue. A click handler has been added to destroy an existing popover before rendering a new one.

---

**Testing**

In a browser verify that clicking on a different episode image when a popover is already active will remove the existing popover and show the correct one.

---

**Deployment steps**

Merge branch `issue4` into `master`

Compile assets: `./bin/node_modules/gulp`
